### PR TITLE
Refactor ProductCard to use global context for favorites and comparison

### DIFF
--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -1,12 +1,20 @@
 import { Link } from 'react-router-dom';
-// Componente principale che rappresenta la card del prodotto e riceve le seguenti props
-export default function ProductCard({
-    product,           // Oggetto prodotto da visualizzare
-    isFavorite,        // Il prodotto è nei preferiti?
-    isCompared,        // Il prodotto è nella lista confronto?
-    onToggleFavorite,  // Funzione da chiamare al click sul cuore
-    onToggleCompare,   // Funzione da chiamare al click sulla lente
-}) {
+// Importa il contesto globale per accedere a funzioni e stati condivisi
+import { useGlobalContext } from '../context/GlobalContext';
+
+// Componente principale che rappresenta la card di un prodotto
+export default function ProductCard({ product }) {
+
+    // Valori ottenuti dal context globale
+    const {
+        favorites,
+        toggleFavorite,
+        compareList,
+        toggleCompare,
+    } = useGlobalContext();
+
+    const isFavorite = favorites.find(fav => fav.id === product.id); // Controlla se il prodotto è nei preferiti
+    const isCompared = compareList.find(comp => comp.id === product.id); // Controlla se il prodotto è nella lista di confronto
 
     // Funzione di utilità per rendere maiuscola la prima lettera di una stringa
     function capitalizeFirstLetter(str) {
@@ -37,13 +45,13 @@ export default function ProductCard({
             <div className="d-flex justify-content-between mt-3 w-100">
                 <button
                     className={`btn btn-sm ${isFavorite ? 'btn-danger' : 'btn-outline-danger'}`} // Cambia stile dinamicamente in base allo stato (preferito o no)
-                    onClick={() => onToggleFavorite(product)} // Al click esegue una funzione che riceve il prodotto e gestisce l'aggiunta/rimozione dai preferiti
+                    onClick={() => toggleFavorite(product)} // Al click esegue una funzione che riceve il prodotto e gestisce l'aggiunta/rimozione dai preferiti
                 >
                     {isFavorite ? '❤️' : '🤍'} {/* Emoji cambia a seconda dello stato */}
                 </button>
                 <button
                     className={`btn btn-sm ${isCompared ? 'btn-warning' : 'btn-outline-warning'}`} // Cambia stile dinamicamente in base allo stato (comparato o no)
-                    onClick={() => onToggleCompare(product)} // Al click esegue una funzione che riceve il prodotto e gestisce l'aggiunta/rimozione dalla lista di confronto
+                    onClick={() => toggleCompare(product)} // Al click esegue una funzione che riceve il prodotto e gestisce l'aggiunta/rimozione dalla lista di confronto
                 >
                     {isCompared ? '🚫' : '🔍'} {/* Emoji cambia a seconda dello stato */}
                 </button>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,4 @@
 // Import dei React Hooks e dei custom hooks/componenti
-import { useGlobalContext } from '../context/GlobalContext';
 import { useState, useMemo, useCallback } from 'react';
 import debounce from '../utils/debounce';
 import useProducts from '../hooks/useProducts';
@@ -16,14 +15,6 @@ function capitalizeFirstLetter(string) {
 export default function Home() {
     // Dati caricati da API tramite hook personalizzato
     const { products, loading, error } = useProducts();
-
-    // Valori ottenuti dal context globale
-    const {
-        favorites,
-        toggleFavorite,
-        compareList,
-        toggleCompare,
-    } = useGlobalContext();
 
     // Stato locale per input visivo dell'utente
     const [searchTerm, setSearchTerm] = useState('');
@@ -149,8 +140,6 @@ export default function Home() {
                         </div>
                     ) : (
                         filteredProducts.map(product => {
-                            const isFavorite = favorites.some(p => p.id === product.id);
-                            const isCompared = compareList.some(p => p.id === product.id);
                             return (
                                 <div
                                     className="col-12 col-sm-8 col-md-6 col-lg-4 mb-4 d-flex justify-content-center mx-auto"
@@ -161,10 +150,6 @@ export default function Home() {
                                             ...product,
                                             category: capitalizeFirstLetter(product.category),
                                         }}
-                                        isFavorite={isFavorite}
-                                        isCompared={isCompared}
-                                        onToggleFavorite={toggleFavorite}
-                                        onToggleCompare={toggleCompare}
                                     />
                                 </div>
                             );

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -22,8 +22,7 @@ export default function Home() {
         favorites,
         toggleFavorite,
         compareList,
-        addToCompare,
-        removeFromCompare,
+        toggleCompare,
     } = useGlobalContext();
 
     // Stato locale per input visivo dell'utente
@@ -165,10 +164,7 @@ export default function Home() {
                                         isFavorite={isFavorite}
                                         isCompared={isCompared}
                                         onToggleFavorite={toggleFavorite}
-                                        onToggleCompare={product => {
-                                            if (isCompared) removeFromCompare(product);
-                                            else addToCompare(product);
-                                        }}
+                                        onToggleCompare={toggleCompare}
                                     />
                                 </div>
                             );


### PR DESCRIPTION
Simplify the compare functionality by utilizing `toggleCompare` and remove unnecessary props from `ProductCard`, leveraging global context for managing favorites and comparison states. This enhances code clarity and reduces prop drilling.